### PR TITLE
Fix libvendor/osm_vendor_ibumad.c so clang -Werror does not complain

### DIFF
--- a/libvendor/osm_vendor_ibumad.c
+++ b/libvendor/osm_vendor_ibumad.c
@@ -743,7 +743,7 @@ osm_vendor_open_port(IN osm_vendor_t * const p_vend,
 	}
 
 	for (ca = 0; ca < p_vend->ca_count; ca++) {
-		if ((r = umad_get_ca_portguids(p_vend->ca_names[ca], portguids,
+		if ((r = umad_get_ca_portguids(p_vend->ca_names[ca], &portguids[0],
 					       OSM_UMAD_MAX_PORTS_PER_CA + 1)) < 0) {
 #ifdef __WIN__
 			OSM_LOG(p_vend->p_log, OSM_LOG_VERBOSE,

--- a/scripts/travis-build
+++ b/scripts/travis-build
@@ -10,8 +10,7 @@ set -x
 ./autogen.sh
 
 
-# Clang doesn't like getting pointers from packed struct members, even if aligned.
-CC=clang CFLAGS="-Wno-address-of-packed-member"  ./configure
+CC=clang CFLAGS="-Werror"  ./configure
 make
 make clean
 


### PR DESCRIPTION
Clang doesn't like getting pointers from packed struct members,
even if aligned

Pointed-out-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>

Signed-off-by: Hal Rosenstock <hal@mellanox.com>