### PR TITLE
Add support for registering an opensm plugin as a new routing engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ aclocal.m4
 autom4te.cache/
 config.log
 config.status
+config/compile
 config/config.guess
 config/config.sub
 config/depcomp

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 
 # note that order matters: make the libs first then use them
 SUBDIRS = complib libopensm libvendor opensm osmtest include $(DEFAULT_EVENT_PLUGIN)
-DIST_SUBDIRS = complib libopensm libvendor opensm osmtest include osmeventplugin
+DIST_SUBDIRS = complib libopensm libvendor opensm osmtest include osmeventplugin osmroutingplugin
 
 ACLOCAL_AMFLAGS = -I config
 

--- a/configure.ac
+++ b/configure.ac
@@ -290,4 +290,4 @@ METIS_CHECK_LIB
 AC_CONFIG_FILES([man/opensm.8 man/torus-2QoS.8 man/torus-2QoS.conf.5 scripts/opensm.init scripts/redhat-opensm.init scripts/sldd.sh])
 
 dnl Create the following Makefiles
-AC_OUTPUT([include/opensm/osm_version.h Makefile include/Makefile complib/Makefile libopensm/Makefile libvendor/Makefile opensm/Makefile osmeventplugin/Makefile osmtest/Makefile opensm.spec])
+AC_OUTPUT([include/opensm/osm_version.h Makefile include/Makefile complib/Makefile libopensm/Makefile libvendor/Makefile opensm/Makefile osmeventplugin/Makefile osmroutingplugin/Makefile osmtest/Makefile opensm.spec])

--- a/include/opensm/osm_opensm.h
+++ b/include/opensm/osm_opensm.h
@@ -113,7 +113,8 @@ typedef enum _osm_routing_engine_type {
 	OSM_ROUTING_ENGINE_TYPE_NUE,
 	OSM_ROUTING_ENGINE_TYPE_SSSP,
 	OSM_ROUTING_ENGINE_TYPE_DFSSSP,
-	OSM_ROUTING_ENGINE_TYPE_UNKNOWN
+	OSM_ROUTING_ENGINE_TYPE_UNKNOWN,
+	OSM_ROUTING_ENGINE_TYPE_EXTERNAL = 100
 } osm_routing_engine_type_t;
 /***********/
 
@@ -127,7 +128,7 @@ typedef enum _osm_routing_engine_type {
 *	routing engine structure - multicast callbacks may be
 *	added later.
 */
-struct osm_routing_engine {
+typedef struct osm_routing_engine {
 	osm_routing_engine_type_t type;
 	const char *name;
 	void *context;
@@ -147,7 +148,44 @@ struct osm_routing_engine {
 					     IN OUT osm_mgrp_box_t *mgb);
 	void (*destroy) (void *context);
 	struct osm_routing_engine *next;
-};
+} osm_routing_engine_t;
+
+/****s* OpenSM: OpenSM/routing_engine_module_t
+ * NAME
+ *	routing_engine_module_t
+ *
+ * DESCRIPTION
+ *	Routing engine module structure.
+ *
+ *	This structure is used to register a new routing engine
+ *
+ * SYNOPSIS
+ */
+typedef struct routing_engine_module {
+	const char *name;
+	osm_routing_engine_type_t type;
+	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
+	void *context;
+} routing_engine_module_t;
+/*
+ * FIELDS
+ *	name
+ *		Name of the routing engine
+ *
+ *	type
+ *		Type (unique identifier) of the routing engine.
+ *      If set to OSM_ROUTING_ENGINE_TYPE_UNKNOWN, a new type will be generated
+ *
+ *	setup
+ *		function to setup the routing engine's callbacks
+ *
+ *	context
+ *		User defined context
+ *
+ * SEE ALSO
+ *    osm_routing_engine, osm_opensm_register_routing_engine
+ *********/
+
 /*
 * FIELDS
 *	name
@@ -602,6 +640,39 @@ osm_opensm_wait_for_subnet_up(IN osm_opensm_t * p_osm, IN uint32_t wait_us,
 *
 * SEE ALSO
 *********/
+
+/****f* OpenSM: OpenSM/osm_opensm_register_routing_engine
+ * NAME
+ *	osm_opensm_register_routing_engine
+ *
+ * DESCRIPTION
+ *	Register a new routing engine.
+ *
+ * SYNOPSIS
+ */
+cl_status_t osm_opensm_register_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT routing_engine_module_t *module,
+	IN void *context);
+/*
+ * PARAMETERS
+ *	type
+ *      [in] Pointer to a osm_opensm_t object
+ *      [in] Pointer to a osm_routing_engine_t object to be registered.
+ *            If module->type is OSM_ROUTING_ENGINE_TYPE_UNKNOWN,
+ *            a new type will be assigned to the module
+ *      [in] Pointer to a user context that will be set in osm_routing_engine_t
+ *
+ * RETURN VALUES
+ *	CL_SUCCESS if the routing engine was registered successfully.
+ *	CL_DUPLICATE if a routing engine with the same name
+ *               or type was already registered.
+ *
+ * NOTES
+ *
+ * SEE ALSO
+ *    routing_engine_module_t
+ *********/
 
 /****f* OpenSM: OpenSM/osm_routing_engine_type_str
 * NAME

--- a/include/opensm/osm_opensm.h
+++ b/include/opensm/osm_opensm.h
@@ -4,6 +4,7 @@
  * Copyright (c) 1996-2003 Intel Corporation. All rights reserved.
  * Copyright (c) 2009-2011 ZIH, TU Dresden, Federal Republic of Germany. All rights reserved.
  * Copyright (C) 2012-2017 Tokyo Institute of Technology. All rights reserved.
+ * Copyright (C) 2019      Fabriscale Technologies AS. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/include/opensm/osm_opensm.h
+++ b/include/opensm/osm_opensm.h
@@ -663,7 +663,7 @@ cl_status_t osm_register_external_routing_engine(
  * NOTES
  *
  * SEE ALSO
- *    routing_engine_module_t
+ *    external_routing_engine_module_t
  *********/
 
 /****f* OpenSM: OpenSM/osm_routing_engine_type_str

--- a/include/opensm/osm_opensm.h
+++ b/include/opensm/osm_opensm.h
@@ -646,7 +646,7 @@ osm_opensm_wait_for_subnet_up(IN osm_opensm_t * p_osm, IN uint32_t wait_us,
  */
 cl_status_t osm_register_external_routing_engine(
 	IN osm_opensm_t *osm,
-	IN OUT external_routing_engine_module_t *module,
+	IN const external_routing_engine_module_t *module,
 	IN void *context);
 /*
  * PARAMETERS

--- a/include/opensm/osm_opensm.h
+++ b/include/opensm/osm_opensm.h
@@ -114,7 +114,7 @@ typedef enum _osm_routing_engine_type {
 	OSM_ROUTING_ENGINE_TYPE_SSSP,
 	OSM_ROUTING_ENGINE_TYPE_DFSSSP,
 	OSM_ROUTING_ENGINE_TYPE_UNKNOWN,
-	OSM_ROUTING_ENGINE_TYPE_EXTERNAL = 100
+	OSM_ROUTING_ENGINE_TYPE_EXTERNAL
 } osm_routing_engine_type_t;
 /***********/
 
@@ -149,43 +149,6 @@ typedef struct osm_routing_engine {
 	void (*destroy) (void *context);
 	struct osm_routing_engine *next;
 } osm_routing_engine_t;
-
-/****s* OpenSM: OpenSM/routing_engine_module_t
- * NAME
- *	routing_engine_module_t
- *
- * DESCRIPTION
- *	Routing engine module structure.
- *
- *	This structure is used to register a new routing engine
- *
- * SYNOPSIS
- */
-typedef struct routing_engine_module {
-	const char *name;
-	osm_routing_engine_type_t type;
-	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
-	void *context;
-} routing_engine_module_t;
-/*
- * FIELDS
- *	name
- *		Name of the routing engine
- *
- *	type
- *		Type (unique identifier) of the routing engine.
- *      If set to OSM_ROUTING_ENGINE_TYPE_UNKNOWN, a new type will be generated
- *
- *	setup
- *		function to setup the routing engine's callbacks
- *
- *	context
- *		User defined context
- *
- * SEE ALSO
- *    osm_routing_engine, osm_opensm_register_routing_engine
- *********/
-
 /*
 * FIELDS
 *	name
@@ -235,6 +198,37 @@ typedef struct routing_engine_module {
 *	next
 *		Pointer to next routing engine in the list.
 */
+
+/****s* OpenSM: OpenSM/external_routing_engine_module_t
+ * NAME
+ *	external_routing_engine_module_t
+ *
+ * DESCRIPTION
+ *	External routing engine module structure.
+ *
+ *	This structure is used to register a new external routing engine
+ *
+ * SYNOPSIS
+ */
+typedef struct external_routing_engine_module {
+	const char *name;
+	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
+	void *context;
+} external_routing_engine_module_t;
+/*
+ * FIELDS
+ *	name
+ *		Name of the external routing engine
+ *
+ *	setup
+ *		function to setup the external routing engine's callbacks
+ *
+ *	context
+ *		User defined context
+ *
+ *	SEE ALSO
+ *		osm_register_external_routing_engine
+ *********/
 
 /****s* OpenSM: OpenSM/osm_opensm_t
 * NAME
@@ -641,26 +635,24 @@ osm_opensm_wait_for_subnet_up(IN osm_opensm_t * p_osm, IN uint32_t wait_us,
 * SEE ALSO
 *********/
 
-/****f* OpenSM: OpenSM/osm_opensm_register_routing_engine
+/****f* OpenSM: OpenSM/osm_register_external_routing_engine
  * NAME
- *	osm_opensm_register_routing_engine
+ *	osm_register_external_routing_engine
  *
  * DESCRIPTION
- *	Register a new routing engine.
+ *	Register a new external routing engine.
  *
  * SYNOPSIS
  */
-cl_status_t osm_opensm_register_routing_engine(
+cl_status_t osm_register_external_routing_engine(
 	IN osm_opensm_t *osm,
-	IN OUT routing_engine_module_t *module,
+	IN OUT external_routing_engine_module_t *module,
 	IN void *context);
 /*
  * PARAMETERS
  *	type
  *      [in] Pointer to a osm_opensm_t object
- *      [in] Pointer to a osm_routing_engine_t object to be registered.
- *            If module->type is OSM_ROUTING_ENGINE_TYPE_UNKNOWN,
- *            a new type will be assigned to the module
+ *      [in] Pointer to a external_routing_engine_module_t object to be registered.
  *      [in] Pointer to a user context that will be set in osm_routing_engine_t
  *
  * RETURN VALUES

--- a/man/opensm.8.in
+++ b/man/opensm.8.in
@@ -1564,7 +1564,7 @@ To learn more about the Nue routing algorithm, see the article "Routing on the
 Dependency Graph: A New Approach to Deadlock-Free High-Performance Routing" by
 J. Domke, T. Hoefler and S. Matsuoka (published in HPDC'16).
 
-Modular Routine Engine
+Modular Routing Engine
 
 Modular routing engine structure allows for the ease of
 "plugging" new routing modules.

--- a/opensm/osm_opensm.c
+++ b/opensm/osm_opensm.c
@@ -4,6 +4,7 @@
  * Copyright (c) 1996-2003 Intel Corporation. All rights reserved.
  * Copyright (c) 2009-2011 ZIH, TU Dresden, Federal Republic of Germany. All rights reserved.
  * Copyright (C) 2012-2017 Tokyo Institute of Technology. All rights reserved.
+ * Copyright (C) 2019      Fabriscale Technologies AS. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/opensm/osm_opensm.c
+++ b/opensm/osm_opensm.c
@@ -101,7 +101,7 @@ typedef struct routing_engine_module {
 /** =========================================================================
  * Local variables
  */
-static const char * unknown_routing_engine_name = "unknown";
+static const char *unknown_routing_engine_name = "unknown";
 
 static cl_list_t routing_modules;
 
@@ -219,7 +219,7 @@ cl_status_t osm_register_external_routing_engine(
 	IN void *context)
 {
 	cl_status_t status;
-	routing_engine_module_t * copy = NULL;
+	routing_engine_module_t *copy = NULL;
 
 	if (!osm || !module)
 		return CL_INVALID_PARAMETER;
@@ -276,7 +276,7 @@ cl_status_t register_routing_engine(
 	osm_routing_engine_type_t type;
 	const char *routing_engine_type;
 
-	routing_engine_type = 
+	routing_engine_type =
 		module->type < OSM_ROUTING_ENGINE_TYPE_UNKNOWN ?
 		"Built-in routing engine" : "External routing engine";
 

--- a/opensm/osm_opensm.c
+++ b/opensm/osm_opensm.c
@@ -50,6 +50,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <complib/cl_dispatcher.h>
+#include <complib/cl_list.h>
 #include <complib/cl_passivelock.h>
 #include <opensm/osm_file_ids.h>
 #define FILE_ID OSM_FILE_OPENSM_C
@@ -64,103 +65,271 @@
 #include <opensm/osm_event_plugin.h>
 #include <opensm/osm_congestion_control.h>
 
-struct routing_engine_module {
-	const char *name;
-	int (*setup) (struct osm_routing_engine *, osm_opensm_t *);
-};
+extern int osm_ucast_minhop_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
 
-extern int osm_ucast_minhop_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_updn_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_dnup_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_file_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_ftree_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_lash_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_dor_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_torus2QoS_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_nue_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_sssp_setup(struct osm_routing_engine *, osm_opensm_t *);
-extern int osm_ucast_dfsssp_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_updn_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
 
-static const struct routing_engine_module routing_modules[] = {
-	{"minhop", osm_ucast_minhop_setup},
-	{"updn", osm_ucast_updn_setup},
-	{"dnup", osm_ucast_dnup_setup},
-	{"file", osm_ucast_file_setup},
-	{"ftree", osm_ucast_ftree_setup},
-	{"lash", osm_ucast_lash_setup},
-	{"dor", osm_ucast_dor_setup},
-	{"torus-2QoS", osm_ucast_torus2QoS_setup},
-	{"nue", osm_ucast_nue_setup},
-	{"dfsssp", osm_ucast_dfsssp_setup},
-	{"sssp", osm_ucast_sssp_setup},
-	{NULL, NULL}
-};
+extern int osm_ucast_dnup_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
 
-const char *osm_routing_engine_type_str(IN osm_routing_engine_type_t type)
-{
-	switch (type) {
-	case OSM_ROUTING_ENGINE_TYPE_NONE:
-		return "none";
-	case OSM_ROUTING_ENGINE_TYPE_MINHOP:
-		return "minhop";
-	case OSM_ROUTING_ENGINE_TYPE_UPDN:
-		return "updn";
-	case OSM_ROUTING_ENGINE_TYPE_DNUP:
-		return "dnup";
-	case OSM_ROUTING_ENGINE_TYPE_FILE:
-		return "file";
-	case OSM_ROUTING_ENGINE_TYPE_FTREE:
-		return "ftree";
-	case OSM_ROUTING_ENGINE_TYPE_LASH:
-		return "lash";
-	case OSM_ROUTING_ENGINE_TYPE_DOR:
-		return "dor";
-	case OSM_ROUTING_ENGINE_TYPE_TORUS_2QOS:
-		return "torus-2QoS";
-	case OSM_ROUTING_ENGINE_TYPE_NUE:
-		return "nue";
-	case OSM_ROUTING_ENGINE_TYPE_DFSSSP:
-		return "dfsssp";
-	case OSM_ROUTING_ENGINE_TYPE_SSSP:
-		return "sssp";
-	default:
-		break;
+extern int osm_ucast_file_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_ftree_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_lash_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_dor_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_torus2QoS_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_nue_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_sssp_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+extern int osm_ucast_dfsssp_setup(
+	struct osm_routing_engine *re, osm_opensm_t *osm);
+
+static cl_list_t routing_modules;
+
+static osm_routing_engine_type_t last_routing_engine_type =
+	OSM_ROUTING_ENGINE_TYPE_EXTERNAL;
+
+static routing_engine_module_t static_routing_modules[] = {
+	{
+		"none",
+		OSM_ROUTING_ENGINE_TYPE_NONE,
+		NULL
+	},
+	{
+		"minhop",
+		OSM_ROUTING_ENGINE_TYPE_MINHOP,
+		osm_ucast_minhop_setup
+	},
+	{
+		"updn",
+		OSM_ROUTING_ENGINE_TYPE_UPDN,
+		osm_ucast_updn_setup
+	},
+	{
+		"dnup",
+		OSM_ROUTING_ENGINE_TYPE_DNUP,
+		osm_ucast_dnup_setup
+	},
+	{
+		"file",
+		OSM_ROUTING_ENGINE_TYPE_FILE,
+		osm_ucast_file_setup
+	},
+	{
+		"ftree",
+		OSM_ROUTING_ENGINE_TYPE_FTREE,
+		osm_ucast_ftree_setup
+	},
+	{
+		"lash",
+		OSM_ROUTING_ENGINE_TYPE_LASH,
+		osm_ucast_lash_setup
+	},
+	{
+		"dor",
+		OSM_ROUTING_ENGINE_TYPE_DOR,
+		osm_ucast_dor_setup
+	},
+	{
+		"torus-2QoS",
+		OSM_ROUTING_ENGINE_TYPE_TORUS_2QOS,
+		osm_ucast_torus2QoS_setup
+	},
+	{
+		"nue",
+		OSM_ROUTING_ENGINE_TYPE_NUE,
+		osm_ucast_nue_setup
+	},
+	{
+		"dfsssp",
+		OSM_ROUTING_ENGINE_TYPE_DFSSSP,
+		osm_ucast_dfsssp_setup
+	},
+	{
+		"sssp",
+		OSM_ROUTING_ENGINE_TYPE_SSSP,
+		osm_ucast_sssp_setup
 	}
+};
+
+/** =========================================================================
+ * Forward declarations
+ */
+struct routing_engine_module_ {
+	char *name;
+	osm_routing_engine_type_t type;
+	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
+	void *context;
+};
+
+static cl_status_t _match_routing_engine_type(
+	IN const void *const p_object, IN void *context);
+
+static cl_status_t _match_routing_engine_str(
+	IN const void *const p_object, IN void *context);
+
+static void append_routing_engine(
+	osm_opensm_t *osm, struct osm_routing_engine *routing_engine);
+
+static struct osm_routing_engine *setup_routing_engine(
+	osm_opensm_t *osm, const char *name);
+
+static void dump_routing_engine(
+	IN void *const p_object, IN void *context);
+
+static void dump_routing_engines(
+	IN osm_opensm_t *osm);
+
+static void setup_routing_engines(
+	osm_opensm_t *osm, const char *engine_names);
+
+static void destroy_routing_engines(
+	osm_opensm_t *osm);
+
+/** =========================================================================
+ */
+cl_status_t osm_opensm_register_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT routing_engine_module_t *module,
+	void *context)
+{
+	cl_status_t status;
+	osm_routing_engine_type_t type;
+	struct routing_engine_module_ *copy;
+	const char *routing_engine_type;
+
+	if (!osm || !module)
+		return CL_INVALID_PARAMETER;
+
+	type = osm_routing_engine_type(module->name);
+
+	routing_engine_type = type < OSM_ROUTING_ENGINE_TYPE_EXTERNAL ?
+		"Built-in routing engine" : "External routing engine";
+
+	if (type != OSM_ROUTING_ENGINE_TYPE_UNKNOWN) {
+		OSM_LOG(&osm->log, OSM_LOG_ERROR,
+			"%s with name '%s' was aleady registered with type: '%d'\n",
+			routing_engine_type,
+			module->name,
+			osm_routing_engine_type(module->name));
+		return CL_DUPLICATE;
+	}
+
+	if (strcmp(osm_routing_engine_type_str(module->type), "unknown") != 0) {
+		OSM_LOG(&osm->log, OSM_LOG_ERROR,
+			"%s with type '%d' was aleady registered with name: '%s'\n",
+			routing_engine_type,
+			module->type,
+			osm_routing_engine_type_str(module->type));
+		return CL_DUPLICATE;
+	}
+
+	if (module->type == OSM_ROUTING_ENGINE_TYPE_UNKNOWN) {
+		OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
+			"Assign type '%d' to %s with name: '%s'\n",
+			last_routing_engine_type,
+			routing_engine_type,
+			module->name);
+		module->type = last_routing_engine_type++;
+	}
+
+	OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
+		"Register %s with name: '%s' and type: '%d'\n",
+		routing_engine_type,
+		module->name, module->type);
+
+	copy = (struct routing_engine_module_ *)
+		malloc(sizeof(struct routing_engine_module_));
+	copy->name = strdup(module->name);
+	copy->setup = module->setup;
+	copy->type = module->type;
+	copy->context = context;
+
+	status = cl_list_insert_tail(&routing_modules, copy);
+	return status;
+}
+
+static cl_status_t _match_routing_engine_type(
+	IN const void *const p_object, IN void *context)
+{
+	osm_routing_engine_type_t type;
+	struct routing_engine_module_ *module;
+
+	type = (osm_routing_engine_type_t) context;
+	module = (struct routing_engine_module_ *) p_object;
+
+	if (module->type == type)
+		return CL_SUCCESS;
+	else
+		return CL_NOT_FOUND;
+}
+
+const char *osm_routing_engine_type_str(
+	IN osm_routing_engine_type_t type)
+{
+	cl_list_iterator_t iter;
+	struct routing_engine_module_ *module;
+
+	iter = cl_list_find_from_head(
+		&routing_modules, _match_routing_engine_type, (void *)type);
+
+	if (iter != cl_list_end(&routing_modules)) {
+		module = (struct routing_engine_module_ *) cl_list_obj(iter);
+		return module->name;
+	}
+
 	return "unknown";
+}
+
+static cl_status_t _match_routing_engine_str(
+	IN const void *const p_object, IN void *context)
+{
+	const char *name = (char *) context;
+	struct routing_engine_module_ *module;
+
+	name = (char *) context;
+	module = (struct routing_engine_module_ *) p_object;
+
+	/* For legacy reasons, consider a NULL pointer and the string
+	 * "null" as the minhop routing engine.
+	 */
+	if (!name || !strcasecmp(name, "null"))
+		name = "minhop";
+
+	if (strcasecmp(module->name, name) == 0)
+		return CL_SUCCESS;
+	else
+		return CL_NOT_FOUND;
 }
 
 osm_routing_engine_type_t osm_routing_engine_type(IN const char *str)
 {
-	/* For legacy reasons, consider a NULL pointer and the string
-	 * "null" as the minhop routing engine.
-	 */
-	if (!str || !strcasecmp(str, "null")
-	    || !strcasecmp(str, "minhop"))
-		return OSM_ROUTING_ENGINE_TYPE_MINHOP;
-	else if (!strcasecmp(str, "none"))
-		return OSM_ROUTING_ENGINE_TYPE_NONE;
-	else if (!strcasecmp(str, "updn"))
-		return OSM_ROUTING_ENGINE_TYPE_UPDN;
-	else if (!strcasecmp(str, "dnup"))
-		return OSM_ROUTING_ENGINE_TYPE_DNUP;
-	else if (!strcasecmp(str, "file"))
-		return OSM_ROUTING_ENGINE_TYPE_FILE;
-	else if (!strcasecmp(str, "ftree"))
-		return OSM_ROUTING_ENGINE_TYPE_FTREE;
-	else if (!strcasecmp(str, "lash"))
-		return OSM_ROUTING_ENGINE_TYPE_LASH;
-	else if (!strcasecmp(str, "dor"))
-		return OSM_ROUTING_ENGINE_TYPE_DOR;
-	else if (!strcasecmp(str, "torus-2QoS"))
-		return OSM_ROUTING_ENGINE_TYPE_TORUS_2QOS;
-	else if (!strcasecmp(str, "nue"))
-		return OSM_ROUTING_ENGINE_TYPE_NUE;
-	else if (!strcasecmp(str, "sssp"))
-		return OSM_ROUTING_ENGINE_TYPE_SSSP;
-	else if (!strcasecmp(str, "dfsssp"))
-		return OSM_ROUTING_ENGINE_TYPE_DFSSSP;
-	else
-		return OSM_ROUTING_ENGINE_TYPE_UNKNOWN;
+	cl_list_iterator_t iter;
+	struct routing_engine_module_ *module;
+
+	iter = cl_list_find_from_head(
+		&routing_modules, _match_routing_engine_str, (void *)str);
+
+	if (iter != cl_list_end(&routing_modules)) {
+		module = (struct routing_engine_module_ *) cl_list_obj(iter);
+		return module->type;
+	}
+
+	return OSM_ROUTING_ENGINE_TYPE_UNKNOWN;
 }
 
 static void append_routing_engine(osm_opensm_t *osm,
@@ -186,14 +355,18 @@ static struct osm_routing_engine *setup_routing_engine(osm_opensm_t *osm,
 						       const char *name)
 {
 	struct osm_routing_engine *re;
-	const struct routing_engine_module *m;
+	struct routing_engine_module_ *m;
+	cl_list_iterator_t iter;
 
 	if (!strcmp(name, "no_fallback")) {
 		osm->no_fallback_routing_engine = TRUE;
 		return NULL;
 	}
 
-	for (m = routing_modules; m->name && *m->name; m++) {
+	for (iter = cl_list_head(&routing_modules);
+		 iter != cl_list_end(&routing_modules);
+		 iter = cl_list_next(iter)) {
+		m = (struct routing_engine_module_ *)cl_list_obj(iter);
 		if (!strcmp(m->name, name)) {
 			re = malloc(sizeof(struct osm_routing_engine));
 			if (!re) {
@@ -204,11 +377,15 @@ static struct osm_routing_engine *setup_routing_engine(osm_opensm_t *osm,
 			memset(re, 0, sizeof(struct osm_routing_engine));
 
 			re->name = m->name;
+			re->context = m->context;
+
+			OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
+				"setup of routing engine '%s' ...\n", name);
+
 			re->type = osm_routing_engine_type(m->name);
 			if (m->setup(re, osm)) {
 				OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
-					"setup of routing"
-					" engine \'%s\' failed\n", name);
+					"setup of routing engine '%s' failed\n", name);
 				free(re);
 				return NULL;
 			}
@@ -230,6 +407,8 @@ static void setup_routing_engines(osm_opensm_t *osm, const char *engine_names)
 	char *name, *str, *p;
 	struct osm_routing_engine *re;
 
+	dump_routing_engines(osm);
+
 	if (engine_names && *engine_names) {
 		str = strdup(engine_names);
 		name = strtok_r(str, ", \t\n", &p);
@@ -237,6 +416,9 @@ static void setup_routing_engines(osm_opensm_t *osm, const char *engine_names)
 			re = setup_routing_engine(osm, name);
 			if (re)
 				append_routing_engine(osm, re);
+			else
+				OSM_LOG(&osm->log, OSM_LOG_ERROR,
+					"Failed to setup routing engine '%s'\n", name);
 			name = strtok_r(NULL, ", \t\n", &p);
 		}
 		free(str);
@@ -245,16 +427,75 @@ static void setup_routing_engines(osm_opensm_t *osm, const char *engine_names)
 		setup_routing_engine(osm, "minhop");
 }
 
-void osm_opensm_construct(IN osm_opensm_t * p_osm)
+static void dump_routing_engine(
+	IN void *const p_object, IN void *context)
+{
+	osm_opensm_t *osm;
+	struct routing_engine_module_ *module;
+
+	osm = (struct osm_opensm_t *) context;
+	module = (struct routing_engine_module_ *) p_object;
+
+	OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
+		"    name: %s - Type: %d\n",
+		module->name, module->type);
+}
+
+static void dump_routing_engines(
+	IN osm_opensm_t *osm)
+{
+	cl_list_apply_func(
+		&routing_modules,
+		dump_routing_engine,
+		(void *) osm);
+}
+
+void osm_routing_modules_construct(
+	IN osm_opensm_t *p_osm)
+{
+	size_t i, len;
+
+	len = sizeof(static_routing_modules) /
+		  sizeof(struct routing_engine_module_);
+
+	cl_list_construct(&routing_modules);
+	cl_list_init(&routing_modules, len);
+	for (i = 0; i < len; i++) {
+		osm_opensm_register_routing_engine(
+			p_osm, &(static_routing_modules[i]), NULL);
+	}
+}
+
+static void __free_routing_module(void *p_object, void *context)
+{
+	struct routing_engine_module_ *p_module;
+
+	p_module = (struct routing_engine_module_ *) p_object;
+	if (p_module) {
+		if (p_module->name)
+			free(p_module->name);
+		free(p_module);
+	}
+}
+
+void osm_routing_modules_destroy(IN osm_opensm_t *p_osm)
+{
+	cl_list_apply_func(&routing_modules, __free_routing_module, p_osm);
+	cl_list_remove_all(&routing_modules);
+	cl_list_destroy(&routing_modules);
+}
+
+void osm_opensm_construct(IN osm_opensm_t *p_osm)
 {
 	memset(p_osm, 0, sizeof(*p_osm));
 	p_osm->osm_version = OSM_VERSION;
+	osm_routing_modules_construct(p_osm);
 	osm_subn_construct(&p_osm->subn);
 	osm_db_construct(&p_osm->db);
 	osm_log_construct(&p_osm->log);
 }
 
-void osm_opensm_construct_finish(IN osm_opensm_t * p_osm)
+void osm_opensm_construct_finish(IN osm_opensm_t *p_osm)
 {
 	osm_sm_construct(&p_osm->sm);
 	osm_sa_construct(&p_osm->sa);
@@ -294,14 +535,14 @@ static void destroy_plugins(osm_opensm_t *osm)
 {
 	osm_epi_plugin_t *p;
 	/* remove from the list, and destroy it */
-	while (!cl_is_qlist_empty(&osm->plugin_list)){
+	while (!cl_is_qlist_empty(&osm->plugin_list)) {
 		p = (osm_epi_plugin_t *)cl_qlist_remove_head(&osm->plugin_list);
 		/* plugin is responsible for freeing its own resources */
 		osm_epi_destroy(p);
 	}
 }
 
-void osm_opensm_destroy(IN osm_opensm_t * p_osm)
+void osm_opensm_destroy(IN osm_opensm_t *p_osm)
 {
 	/* in case of shutdown through exit proc - no ^C */
 	osm_exit_flag = TRUE;
@@ -344,17 +585,18 @@ void osm_opensm_destroy(IN osm_opensm_t * p_osm)
 		osm_sa_db_file_dump(p_osm);
 
 	/* do the destruction in reverse order as init */
-	destroy_plugins(p_osm);
 	destroy_routing_engines(p_osm);
+	destroy_plugins(p_osm);
 	osm_sa_destroy(&p_osm->sa);
 	osm_sm_destroy(&p_osm->sm);
+	osm_routing_modules_destroy(p_osm);
 #ifdef ENABLE_OSM_PERF_MGR
 	osm_perfmgr_destroy(&p_osm->perfmgr);
 #endif				/* ENABLE_OSM_PERF_MGR */
 	osm_congestion_control_destroy(&p_osm->cc);
 }
 
-void osm_opensm_destroy_finish(IN osm_opensm_t * p_osm)
+void osm_opensm_destroy_finish(IN osm_opensm_t *p_osm)
 {
 	osm_db_destroy(&p_osm->db);
 	if (p_osm->vl15_constructed && p_osm->mad_pool_constructed)
@@ -401,8 +643,8 @@ static void load_plugins(osm_opensm_t *osm, const char *plugin_names)
 	free(p_names);
 }
 
-ib_api_status_t osm_opensm_init(IN osm_opensm_t * p_osm,
-				IN const osm_subn_opt_t * p_opt)
+ib_api_status_t osm_opensm_init(IN osm_opensm_t *p_osm,
+				IN const osm_subn_opt_t *p_opt)
 {
 	ib_api_status_t status;
 
@@ -485,8 +727,8 @@ Exit:
 	return status;
 }
 
-ib_api_status_t osm_opensm_init_finish(IN osm_opensm_t * p_osm,
-				       IN const osm_subn_opt_t * p_opt)
+ib_api_status_t osm_opensm_init_finish(IN osm_opensm_t *p_osm,
+				       IN const osm_subn_opt_t *p_opt)
 {
 	ib_api_status_t status;
 
@@ -549,7 +791,7 @@ Exit:
 	return status;
 }
 
-ib_api_status_t osm_opensm_bind(IN osm_opensm_t * p_osm, IN ib_net64_t guid)
+ib_api_status_t osm_opensm_bind(IN osm_opensm_t *p_osm, IN ib_net64_t guid)
 {
 	ib_api_status_t status;
 
@@ -587,11 +829,12 @@ void osm_opensm_report_event(osm_opensm_t *osm, osm_epi_event_id_t event_id,
 			     void *event_data)
 {
 	cl_list_item_t *item;
+	osm_epi_plugin_t *p;
 
 	for (item = cl_qlist_head(&osm->plugin_list);
 	     !osm_exit_flag && item != cl_qlist_end(&osm->plugin_list);
 	     item = cl_qlist_next(item)) {
-		osm_epi_plugin_t *p = (osm_epi_plugin_t *)item;
+		p = (osm_epi_plugin_t *)item;
 		if (p->impl->report)
 			p->impl->report(p->plugin_data, event_id, event_data);
 	}

--- a/opensm/osm_opensm.c
+++ b/opensm/osm_opensm.c
@@ -65,45 +65,50 @@
 #include <opensm/osm_event_plugin.h>
 #include <opensm/osm_congestion_control.h>
 
-extern int osm_ucast_minhop_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
+/** =========================================================================
+ * built-in routing engine setup functions
+ */
+extern int osm_ucast_minhop_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_updn_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_dnup_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_file_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_ftree_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_lash_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_dor_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_torus2QoS_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_nue_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_sssp_setup(struct osm_routing_engine *, osm_opensm_t *);
+extern int osm_ucast_dfsssp_setup(struct osm_routing_engine *, osm_opensm_t *);
 
-extern int osm_ucast_updn_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
+/** =========================================================================
+ * Local types
+ */
 
-extern int osm_ucast_dnup_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
+typedef struct builtin_routing_engine_module {
+	const char *name;
+	osm_routing_engine_type_t type;
+	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
+} builtin_routing_engine_module_t;
 
-extern int osm_ucast_file_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
+typedef struct routing_engine_module {
+	char *name;
+	osm_routing_engine_type_t type;
+	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
+	void *context;
+} routing_engine_module_t;
 
-extern int osm_ucast_ftree_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
 
-extern int osm_ucast_lash_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
-
-extern int osm_ucast_dor_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
-
-extern int osm_ucast_torus2QoS_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
-
-extern int osm_ucast_nue_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
-
-extern int osm_ucast_sssp_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
-
-extern int osm_ucast_dfsssp_setup(
-	struct osm_routing_engine *re, osm_opensm_t *osm);
+/** =========================================================================
+ * Local variables
+ */
+static const char * unknown_routing_engine_name = "unknown";
 
 static cl_list_t routing_modules;
 
-static osm_routing_engine_type_t last_routing_engine_type =
+static osm_routing_engine_type_t last_external_routing_engine_type =
 	OSM_ROUTING_ENGINE_TYPE_EXTERNAL;
 
-static routing_engine_module_t static_routing_modules[] = {
+static builtin_routing_engine_module_t static_routing_modules[] = {
 	{
 		"none",
 		OSM_ROUTING_ENGINE_TYPE_NONE,
@@ -169,12 +174,6 @@ static routing_engine_module_t static_routing_modules[] = {
 /** =========================================================================
  * Forward declarations
  */
-struct routing_engine_module_ {
-	char *name;
-	osm_routing_engine_type_t type;
-	int (*setup)(struct osm_routing_engine *re, struct osm_opensm *osm);
-	void *context;
-};
 
 static cl_status_t _match_routing_engine_type(
 	IN const void *const p_object, IN void *context);
@@ -197,69 +196,115 @@ static void dump_routing_engines(
 static void setup_routing_engines(
 	osm_opensm_t *osm, const char *engine_names);
 
+static cl_status_t register_builtin_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT builtin_routing_engine_module_t *module);
+
+static cl_status_t register_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT routing_engine_module_t *module);
+
 static void destroy_routing_engines(
 	osm_opensm_t *osm);
 
+static void __free_routing_module(
+	void *p_object, void *context);
+
 /** =========================================================================
  */
-cl_status_t osm_opensm_register_routing_engine(
+
+cl_status_t osm_register_external_routing_engine(
 	IN osm_opensm_t *osm,
-	IN OUT routing_engine_module_t *module,
-	void *context)
+	IN OUT external_routing_engine_module_t *module,
+	IN void *context)
 {
 	cl_status_t status;
-	osm_routing_engine_type_t type;
-	struct routing_engine_module_ *copy;
-	const char *routing_engine_type;
+	routing_engine_module_t * copy = NULL;
 
 	if (!osm || !module)
 		return CL_INVALID_PARAMETER;
 
-	type = osm_routing_engine_type(module->name);
+	OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
+		"Assign type '%d' to external routing engine with name: \'%s\'\n",
+		last_external_routing_engine_type,
+		module->name);
 
-	routing_engine_type = type < OSM_ROUTING_ENGINE_TYPE_EXTERNAL ?
+	copy = (routing_engine_module_t *)
+		malloc(sizeof(routing_engine_module_t));
+	copy->name = strdup(module->name);
+	copy->setup = module->setup;
+	copy->type = last_external_routing_engine_type++;
+	copy->context = context;
+
+	status = register_routing_engine(osm, copy);
+	if (status != CL_SUCCESS) {
+		__free_routing_module(copy, NULL);
+	}
+	return status;
+}
+
+
+cl_status_t register_builtin_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT builtin_routing_engine_module_t *module)
+{
+	cl_status_t status;
+	routing_engine_module_t * copy;
+
+	if (!osm || !module)
+		return CL_INVALID_PARAMETER;
+
+	copy = (routing_engine_module_t *)
+		malloc(sizeof(routing_engine_module_t));
+	copy->name = strdup(module->name);
+	copy->setup = module->setup;
+	copy->type = module->type;
+	copy->context = NULL;
+
+	status = register_routing_engine(osm, copy);
+	if (status != CL_SUCCESS) {
+		__free_routing_module(copy, NULL);
+	}
+	return status;
+}
+
+cl_status_t register_routing_engine(
+	IN osm_opensm_t *osm,
+	IN OUT routing_engine_module_t *module)
+{
+	cl_status_t status;
+	osm_routing_engine_type_t type;
+	const char *routing_engine_type;
+
+	routing_engine_type = 
+		module->type < OSM_ROUTING_ENGINE_TYPE_UNKNOWN ?
 		"Built-in routing engine" : "External routing engine";
 
+	type = osm_routing_engine_type(module->name);
 	if (type != OSM_ROUTING_ENGINE_TYPE_UNKNOWN) {
 		OSM_LOG(&osm->log, OSM_LOG_ERROR,
-			"%s with name '%s' was aleady registered with type: '%d'\n",
+			"%s with name \'%s\' was already registered with type: '%d'\n",
 			routing_engine_type,
 			module->name,
-			osm_routing_engine_type(module->name));
+			type);
 		return CL_DUPLICATE;
 	}
 
-	if (strcmp(osm_routing_engine_type_str(module->type), "unknown") != 0) {
+	if (strcmp(osm_routing_engine_type_str(module->type), unknown_routing_engine_name) != 0) {
 		OSM_LOG(&osm->log, OSM_LOG_ERROR,
-			"%s with type '%d' was aleady registered with name: '%s'\n",
+			"%s with type '%d' was already registered with name: \'%s\'\n",
 			routing_engine_type,
 			module->type,
 			osm_routing_engine_type_str(module->type));
 		return CL_DUPLICATE;
 	}
 
-	if (module->type == OSM_ROUTING_ENGINE_TYPE_UNKNOWN) {
-		OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
-			"Assign type '%d' to %s with name: '%s'\n",
-			last_routing_engine_type,
-			routing_engine_type,
-			module->name);
-		module->type = last_routing_engine_type++;
-	}
-
 	OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
-		"Register %s with name: '%s' and type: '%d'\n",
+		"Register %s with name: \'%s\' and type: '%d'\n",
 		routing_engine_type,
 		module->name, module->type);
 
-	copy = (struct routing_engine_module_ *)
-		malloc(sizeof(struct routing_engine_module_));
-	copy->name = strdup(module->name);
-	copy->setup = module->setup;
-	copy->type = module->type;
-	copy->context = context;
-
-	status = cl_list_insert_tail(&routing_modules, copy);
+	status = cl_list_insert_tail(&routing_modules, module);
 	return status;
 }
 
@@ -267,10 +312,10 @@ static cl_status_t _match_routing_engine_type(
 	IN const void *const p_object, IN void *context)
 {
 	osm_routing_engine_type_t type;
-	struct routing_engine_module_ *module;
+	routing_engine_module_t *module;
 
 	type = (osm_routing_engine_type_t) context;
-	module = (struct routing_engine_module_ *) p_object;
+	module = (routing_engine_module_t *) p_object;
 
 	if (module->type == type)
 		return CL_SUCCESS;
@@ -282,27 +327,26 @@ const char *osm_routing_engine_type_str(
 	IN osm_routing_engine_type_t type)
 {
 	cl_list_iterator_t iter;
-	struct routing_engine_module_ *module;
+	routing_engine_module_t *module;
 
 	iter = cl_list_find_from_head(
 		&routing_modules, _match_routing_engine_type, (void *)type);
 
 	if (iter != cl_list_end(&routing_modules)) {
-		module = (struct routing_engine_module_ *) cl_list_obj(iter);
+		module = (routing_engine_module_t *) cl_list_obj(iter);
 		return module->name;
 	}
-
-	return "unknown";
+	return unknown_routing_engine_name;
 }
 
 static cl_status_t _match_routing_engine_str(
 	IN const void *const p_object, IN void *context)
 {
 	const char *name = (char *) context;
-	struct routing_engine_module_ *module;
+	routing_engine_module_t *module;
 
 	name = (char *) context;
-	module = (struct routing_engine_module_ *) p_object;
+	module = (routing_engine_module_t *) p_object;
 
 	/* For legacy reasons, consider a NULL pointer and the string
 	 * "null" as the minhop routing engine.
@@ -319,13 +363,13 @@ static cl_status_t _match_routing_engine_str(
 osm_routing_engine_type_t osm_routing_engine_type(IN const char *str)
 {
 	cl_list_iterator_t iter;
-	struct routing_engine_module_ *module;
+	routing_engine_module_t *module;
 
 	iter = cl_list_find_from_head(
 		&routing_modules, _match_routing_engine_str, (void *)str);
 
 	if (iter != cl_list_end(&routing_modules)) {
-		module = (struct routing_engine_module_ *) cl_list_obj(iter);
+		module = (routing_engine_module_t *) cl_list_obj(iter);
 		return module->type;
 	}
 
@@ -355,7 +399,7 @@ static struct osm_routing_engine *setup_routing_engine(osm_opensm_t *osm,
 						       const char *name)
 {
 	struct osm_routing_engine *re;
-	struct routing_engine_module_ *m;
+	routing_engine_module_t *m;
 	cl_list_iterator_t iter;
 
 	if (!strcmp(name, "no_fallback")) {
@@ -366,7 +410,7 @@ static struct osm_routing_engine *setup_routing_engine(osm_opensm_t *osm,
 	for (iter = cl_list_head(&routing_modules);
 		 iter != cl_list_end(&routing_modules);
 		 iter = cl_list_next(iter)) {
-		m = (struct routing_engine_module_ *)cl_list_obj(iter);
+		m = (routing_engine_module_t *)cl_list_obj(iter);
 		if (!strcmp(m->name, name)) {
 			re = malloc(sizeof(struct osm_routing_engine));
 			if (!re) {
@@ -380,12 +424,13 @@ static struct osm_routing_engine *setup_routing_engine(osm_opensm_t *osm,
 			re->context = m->context;
 
 			OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
-				"setup of routing engine '%s' ...\n", name);
+				"setup of routing engine \'%s\' ...\n", name);
 
 			re->type = osm_routing_engine_type(m->name);
 			if (m->setup(re, osm)) {
 				OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
-					"setup of routing engine '%s' failed\n", name);
+					"setup of routing"
+					" engine \'%s\' failed\n", name);
 				free(re);
 				return NULL;
 			}
@@ -418,7 +463,7 @@ static void setup_routing_engines(osm_opensm_t *osm, const char *engine_names)
 				append_routing_engine(osm, re);
 			else
 				OSM_LOG(&osm->log, OSM_LOG_ERROR,
-					"Failed to setup routing engine '%s'\n", name);
+					"Failed to setup routing engine \'%s\'\n", name);
 			name = strtok_r(NULL, ", \t\n", &p);
 		}
 		free(str);
@@ -431,10 +476,10 @@ static void dump_routing_engine(
 	IN void *const p_object, IN void *context)
 {
 	osm_opensm_t *osm;
-	struct routing_engine_module_ *module;
+	routing_engine_module_t *module;
 
-	osm = (struct osm_opensm_t *) context;
-	module = (struct routing_engine_module_ *) p_object;
+	osm = (osm_opensm_t *) context;
+	module = (routing_engine_module_t *) p_object;
 
 	OSM_LOG(&osm->log, OSM_LOG_VERBOSE,
 		"    name: %s - Type: %d\n",
@@ -456,21 +501,21 @@ void osm_routing_modules_construct(
 	size_t i, len;
 
 	len = sizeof(static_routing_modules) /
-		  sizeof(struct routing_engine_module_);
+		  sizeof(builtin_routing_engine_module_t);
 
 	cl_list_construct(&routing_modules);
 	cl_list_init(&routing_modules, len);
 	for (i = 0; i < len; i++) {
-		osm_opensm_register_routing_engine(
-			p_osm, &(static_routing_modules[i]), NULL);
+		register_builtin_routing_engine(
+			p_osm, &(static_routing_modules[i]));
 	}
 }
 
 static void __free_routing_module(void *p_object, void *context)
 {
-	struct routing_engine_module_ *p_module;
+	routing_engine_module_t *p_module;
 
-	p_module = (struct routing_engine_module_ *) p_object;
+	p_module = (routing_engine_module_t *) p_object;
 	if (p_module) {
 		if (p_module->name)
 			free(p_module->name);
@@ -485,7 +530,7 @@ void osm_routing_modules_destroy(IN osm_opensm_t *p_osm)
 	cl_list_destroy(&routing_modules);
 }
 
-void osm_opensm_construct(IN osm_opensm_t *p_osm)
+void osm_opensm_construct(IN osm_opensm_t * p_osm)
 {
 	memset(p_osm, 0, sizeof(*p_osm));
 	p_osm->osm_version = OSM_VERSION;
@@ -495,7 +540,7 @@ void osm_opensm_construct(IN osm_opensm_t *p_osm)
 	osm_log_construct(&p_osm->log);
 }
 
-void osm_opensm_construct_finish(IN osm_opensm_t *p_osm)
+void osm_opensm_construct_finish(IN osm_opensm_t * p_osm)
 {
 	osm_sm_construct(&p_osm->sm);
 	osm_sa_construct(&p_osm->sa);
@@ -535,14 +580,14 @@ static void destroy_plugins(osm_opensm_t *osm)
 {
 	osm_epi_plugin_t *p;
 	/* remove from the list, and destroy it */
-	while (!cl_is_qlist_empty(&osm->plugin_list)) {
+	while (!cl_is_qlist_empty(&osm->plugin_list)){
 		p = (osm_epi_plugin_t *)cl_qlist_remove_head(&osm->plugin_list);
 		/* plugin is responsible for freeing its own resources */
 		osm_epi_destroy(p);
 	}
 }
 
-void osm_opensm_destroy(IN osm_opensm_t *p_osm)
+void osm_opensm_destroy(IN osm_opensm_t * p_osm)
 {
 	/* in case of shutdown through exit proc - no ^C */
 	osm_exit_flag = TRUE;
@@ -596,7 +641,7 @@ void osm_opensm_destroy(IN osm_opensm_t *p_osm)
 	osm_congestion_control_destroy(&p_osm->cc);
 }
 
-void osm_opensm_destroy_finish(IN osm_opensm_t *p_osm)
+void osm_opensm_destroy_finish(IN osm_opensm_t * p_osm)
 {
 	osm_db_destroy(&p_osm->db);
 	if (p_osm->vl15_constructed && p_osm->mad_pool_constructed)
@@ -643,8 +688,8 @@ static void load_plugins(osm_opensm_t *osm, const char *plugin_names)
 	free(p_names);
 }
 
-ib_api_status_t osm_opensm_init(IN osm_opensm_t *p_osm,
-				IN const osm_subn_opt_t *p_opt)
+ib_api_status_t osm_opensm_init(IN osm_opensm_t * p_osm,
+				IN const osm_subn_opt_t * p_opt)
 {
 	ib_api_status_t status;
 
@@ -727,8 +772,8 @@ Exit:
 	return status;
 }
 
-ib_api_status_t osm_opensm_init_finish(IN osm_opensm_t *p_osm,
-				       IN const osm_subn_opt_t *p_opt)
+ib_api_status_t osm_opensm_init_finish(IN osm_opensm_t * p_osm,
+				       IN const osm_subn_opt_t * p_opt)
 {
 	ib_api_status_t status;
 
@@ -791,7 +836,7 @@ Exit:
 	return status;
 }
 
-ib_api_status_t osm_opensm_bind(IN osm_opensm_t *p_osm, IN ib_net64_t guid)
+ib_api_status_t osm_opensm_bind(IN osm_opensm_t * p_osm, IN ib_net64_t guid)
 {
 	ib_api_status_t status;
 
@@ -829,12 +874,11 @@ void osm_opensm_report_event(osm_opensm_t *osm, osm_epi_event_id_t event_id,
 			     void *event_data)
 {
 	cl_list_item_t *item;
-	osm_epi_plugin_t *p;
 
 	for (item = cl_qlist_head(&osm->plugin_list);
 	     !osm_exit_flag && item != cl_qlist_end(&osm->plugin_list);
 	     item = cl_qlist_next(item)) {
-		p = (osm_epi_plugin_t *)item;
+		osm_epi_plugin_t *p = (osm_epi_plugin_t *)item;
 		if (p->impl->report)
 			p->impl->report(p->plugin_data, event_id, event_data);
 	}

--- a/osmeventplugin/src/osmeventplugin.c
+++ b/osmeventplugin/src/osmeventplugin.c
@@ -52,49 +52,136 @@
 #include <opensm/osm_log.h>
 
 /** =========================================================================
- * This is a simple example plugin which logs some of the events the OSM
- * generates to this interface.
+ * This is a simple example plugin which:
+ *  1) Implement the routing engine API
+ *  2) logs some of the events the OSM generates to this interface.
  */
+
 #define SAMPLE_PLUGIN_OUTPUT_FILE "/tmp/osm_sample_event_plugin_output"
-typedef struct _log_events {
+
+struct  plugin_t {
+	osm_opensm_t *osm;
 	FILE *log_file;
-	osm_log_t *osmlog;
-} _log_events_t;
+};
 
 /** =========================================================================
+ * Forward declarations
+ */
+static void *construct(osm_opensm_t *osm);
+
+static void destroy(void *context);
+
+static void report(
+	void *context,
+	osm_epi_event_id_t event_id,
+	void *event_data);
+
+static int plugin_build_lid_matrices(
+	IN void *context);
+
+static int plugin_ucast_build_fwd_tables(
+	IN void *context);
+
+static void plugin_ucast_dump_tables(
+	IN void *context);
+
+static void plugin_update_sl2vl(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t in_port_num,
+	IN uint8_t out_port_num,
+	IN OUT ib_slvl_table_t *t);
+
+static void plugin_update_vlarb(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t port_num,
+	IN OUT ib_vl_arb_table_t *block,
+	unsigned int block_length,
+	unsigned int block_num);
+
+static uint8_t plugin_path_sl(
+	IN void *context,
+	IN uint8_t path_sl_hint,
+	IN const ib_net16_t slid,
+	IN const ib_net16_t dlid);
+
+static ib_api_status_t plugin_mcast_build_stree(
+	IN void *context,
+	IN OUT osm_mgrp_box_t *mgb);
+
+static void plugin_destroy_routing_engine(
+	IN void *context);
+
+static int routing_engine_setup(
+	osm_routing_engine_t *engine,
+	osm_opensm_t *osm);
+
+/** =========================================================================
+ * Implement plugin functions
  */
 static void *construct(osm_opensm_t *osm)
 {
-	_log_events_t *log = malloc(sizeof(*log));
-	if (!log)
-		return (NULL);
+	struct plugin_t *plugin;
+	cl_status_t status;
 
-	log->log_file = fopen(SAMPLE_PLUGIN_OUTPUT_FILE, "a+");
+	plugin = (struct plugin_t *) calloc(1, sizeof(struct plugin_t));
+	if (!plugin)
+		return NULL;
 
-	if (!(log->log_file)) {
+	plugin->osm = osm;
+	routing_engine_module_t plugin_routing_engine_module = {
+		 "routing_engine_plugin",
+		  OSM_ROUTING_ENGINE_TYPE_UNKNOWN, /* Generate a new type */
+		  routing_engine_setup,
+		  plugin,
+	};
+
+	status = osm_opensm_register_routing_engine(
+		osm, &plugin_routing_engine_module, plugin);
+	if (status != CL_SUCCESS) {
+		destroy(plugin);
+		return NULL;
+	}
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"External routing engine '%s' has been registered with type '%d'\n",
+		plugin_routing_engine_module.name,
+		plugin_routing_engine_module.type);
+
+	plugin->log_file = fopen(SAMPLE_PLUGIN_OUTPUT_FILE, "a+");
+	if (!(plugin->log_file)) {
 		osm_log(&osm->log, OSM_LOG_ERROR,
 			"Sample Event Plugin: Failed to open output file \"%s\"\n",
 			SAMPLE_PLUGIN_OUTPUT_FILE);
-		free(log);
-		return (NULL);
+		destroy(plugin);
+		return NULL;
 	}
 
-	log->osmlog = &osm->log;
-	return ((void *)log);
+	return ((void *)plugin);
 }
 
 /** =========================================================================
  */
-static void destroy(void *_log)
+static void destroy(void *context)
 {
-	_log_events_t *log = (_log_events_t *) _log;
-	fclose(log->log_file);
-	free(log);
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	if (plugin) {
+		OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+			"Destroying plugin...\n");
+
+		if (plugin->log_file)
+			fclose(plugin->log_file);
+
+		free(plugin);
+	}
 }
 
 /** =========================================================================
  */
-static void handle_port_counter(_log_events_t * log, osm_epi_pe_event_t * pc)
+static void handle_port_counter(
+	struct plugin_t *plugin, osm_epi_pe_event_t *pc)
 {
 	if (pc->symbol_err_cnt > 0
 	    || pc->link_err_recover > 0
@@ -109,7 +196,7 @@ static void handle_port_counter(_log_events_t * log, osm_epi_pe_event_t * pc)
 	    || pc->buffer_overrun > 0
 	    || pc->vl15_dropped > 0
 	    || pc->xmit_wait > 0) {
-		fprintf(log->log_file,
+		fprintf(plugin->log_file,
 			"Port counter errors for node 0x%" PRIx64
 			" (%s) port %d\n", pc->port_id.node_guid,
 			pc->port_id.node_name, pc->port_id.port_num);
@@ -119,20 +206,22 @@ static void handle_port_counter(_log_events_t * log, osm_epi_pe_event_t * pc)
 /** =========================================================================
  */
 static void
-handle_port_counter_ext(_log_events_t * log, osm_epi_dc_event_t * epc)
+handle_port_counter_ext(
+	struct plugin_t *plugin, osm_epi_dc_event_t *epc)
 {
-	fprintf(log->log_file,
-		"Recieved Data counters for node 0x%" PRIx64 " (%s) port %d\n",
+	fprintf(plugin->log_file,
+		"Received Data counters for node 0x%" PRIx64 " (%s) port %d\n",
 		epc->port_id.node_guid,
 		epc->port_id.node_name, epc->port_id.port_num);
 }
 
 /** =========================================================================
  */
-static void handle_port_select(_log_events_t * log, osm_epi_ps_event_t * ps)
+static void handle_port_select(
+	struct plugin_t *plugin, osm_epi_ps_event_t *ps)
 {
 	if (ps->xmit_wait > 0) {
-		fprintf(log->log_file,
+		fprintf(plugin->log_file,
 			"Port select Xmit Wait counts for node 0x%" PRIx64
 			" (%s) port %d\n", ps->port_id.node_guid,
 			ps->port_id.node_name, ps->port_id.port_num);
@@ -141,16 +230,17 @@ static void handle_port_select(_log_events_t * log, osm_epi_ps_event_t * ps)
 
 /** =========================================================================
  */
-static void handle_trap_event(_log_events_t *log, ib_mad_notice_attr_t *p_ntc)
+static void handle_trap_event(
+	struct plugin_t *plugin, ib_mad_notice_attr_t *p_ntc)
 {
 	if (ib_notice_is_generic(p_ntc)) {
-		fprintf(log->log_file,
+		fprintf(plugin->log_file,
 			"Generic trap type %d; event %d; from LID %u\n",
 			ib_notice_get_type(p_ntc),
 			cl_ntoh16(p_ntc->g_or_v.generic.trap_num),
 			cl_ntoh16(p_ntc->issuer_lid));
 	} else {
-		fprintf(log->log_file,
+		fprintf(plugin->log_file,
 			"Vendor trap type %d; from LID %u\n",
 			ib_notice_get_type(p_ntc),
 			cl_ntoh16(p_ntc->issuer_lid));
@@ -160,10 +250,11 @@ static void handle_trap_event(_log_events_t *log, ib_mad_notice_attr_t *p_ntc)
 
 /** =========================================================================
  */
-static void handle_lft_change_event(_log_events_t *log,
-				    osm_epi_lft_change_event_t *lft_change)
+static void handle_lft_change_event(
+	struct plugin_t *plugin,
+	osm_epi_lft_change_event_t *lft_change)
 {
-	fprintf(log->log_file,
+	fprintf(plugin->log_file,
 		"LFT changed for switch 0x%" PRIx64 " flags 0x%x LFTTop %u block %d\n",
 		cl_ntoh64(osm_node_get_node_guid(lft_change->p_sw->p_node)),
 		lft_change->flags, lft_change->lft_top, lft_change->block_num);
@@ -171,51 +262,174 @@ static void handle_lft_change_event(_log_events_t *log,
 
 /** =========================================================================
  */
-static void report(void *_log, osm_epi_event_id_t event_id, void *event_data)
+static void report(
+	void *context,
+	osm_epi_event_id_t event_id,
+	void *event_data)
 {
-	_log_events_t *log = (_log_events_t *) _log;
+	struct plugin_t *plugin = (struct plugin_t *) context;
 
 	switch (event_id) {
 	case OSM_EVENT_ID_PORT_ERRORS:
-		handle_port_counter(log, (osm_epi_pe_event_t *) event_data);
+		handle_port_counter(
+			plugin, (osm_epi_pe_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_PORT_DATA_COUNTERS:
-		handle_port_counter_ext(log, (osm_epi_dc_event_t *) event_data);
+		handle_port_counter_ext(
+			plugin, (osm_epi_dc_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_PORT_SELECT:
-		handle_port_select(log, (osm_epi_ps_event_t *) event_data);
+		handle_port_select(
+			plugin, (osm_epi_ps_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_TRAP:
-		handle_trap_event(log, (ib_mad_notice_attr_t *) event_data);
+		handle_trap_event(
+			plugin, (ib_mad_notice_attr_t *) event_data);
 		break;
 	case OSM_EVENT_ID_SUBNET_UP:
-		fprintf(log->log_file, "Subnet up reported\n");
+		fprintf(plugin->log_file, "Subnet up reported\n");
 		break;
 	case OSM_EVENT_ID_HEAVY_SWEEP_START:
-		fprintf(log->log_file, "Heavy sweep started\n");
+		fprintf(plugin->log_file, "Heavy sweep started\n");
 		break;
 	case OSM_EVENT_ID_HEAVY_SWEEP_DONE:
-		fprintf(log->log_file, "Heavy sweep completed\n");
+		fprintf(plugin->log_file, "Heavy sweep completed\n");
 		break;
 	case OSM_EVENT_ID_UCAST_ROUTING_DONE:
-		fprintf(log->log_file, "Unicast routing completed %d\n",
+		fprintf(plugin->log_file, "Unicast routing completed %d\n",
 			(osm_epi_ucast_routing_flags_t) event_data);
 		break;
 	case OSM_EVENT_ID_STATE_CHANGE:
-		fprintf(log->log_file, "SM state changed\n");
+		fprintf(plugin->log_file, "SM state changed\n");
 		break;
 	case OSM_EVENT_ID_SA_DB_DUMPED:
-		fprintf(log->log_file, "SA DB dump file updated\n");
+		fprintf(plugin->log_file, "SA DB dump file updated\n");
 		break;
 	case OSM_EVENT_ID_LFT_CHANGE:
-		handle_lft_change_event(log, (osm_epi_lft_change_event_t *) event_data);
+		handle_lft_change_event(
+			plugin, (osm_epi_lft_change_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_MAX:
 	default:
-		osm_log(log->osmlog, OSM_LOG_ERROR,
+		osm_log(&plugin->osm->log, OSM_LOG_ERROR,
 			"Unknown event (%d) reported to plugin\n", event_id);
 	}
-	fflush(log->log_file);
+	fflush(plugin->log_file);
+}
+
+/** =========================================================================
+ * Implement routing engine functions
+ */
+int routing_engine_setup(
+	osm_routing_engine_t *engine,
+	osm_opensm_t *osm)
+{
+	struct plugin_t *plugin = (struct plugin_t *) engine->context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Setting up the plugin as a new routing engine...\n");
+
+	engine->build_lid_matrices = plugin_build_lid_matrices;
+	engine->ucast_build_fwd_tables = plugin_ucast_build_fwd_tables;
+	engine->ucast_dump_tables = plugin_ucast_dump_tables;
+	engine->update_sl2vl = plugin_update_sl2vl;
+	engine->update_vlarb = plugin_update_vlarb;
+	engine->path_sl = plugin_path_sl;
+	engine->mcast_build_stree = plugin_mcast_build_stree;
+	engine->destroy = plugin_destroy_routing_engine;
+
+	return 0;
+}
+
+static int plugin_build_lid_matrices(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_ERROR,
+		"Building LID matrices...\n");
+
+	return 0;
+}
+
+static int plugin_ucast_build_fwd_tables(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Building Forwarding tables...\n");
+	return 0;
+}
+
+static void plugin_ucast_dump_tables(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Dumping Unicast forwarding tables...\n");
+}
+
+static void plugin_update_sl2vl(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t in_port_num, IN uint8_t out_port_num,
+	IN OUT ib_slvl_table_t *t)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Update Service Layer to Virtual Lanes mapping...\n");
+}
+
+static void plugin_update_vlarb(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t port_num,
+	IN OUT ib_vl_arb_table_t *block,
+	unsigned int block_length,
+	unsigned int block_num)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Update Virtual Lane arbritration...\n");
+}
+
+static uint8_t plugin_path_sl(
+	IN void *context,
+	IN uint8_t path_sl_hint,
+	IN const ib_net16_t slid,
+	IN const ib_net16_t dlid)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Computing Service Layer for the path LID %d -> LID %d with hint: %d...\n",
+		slid, dlid, path_sl_hint);
+	return 0;
+}
+
+static ib_api_status_t plugin_mcast_build_stree(
+	IN void *context,
+	IN OUT osm_mgrp_box_t *mgb)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Building spanning tree for MLID: %d\n",
+		mgb->mlid);
+	return IB_SUCCESS;
+}
+
+static void plugin_destroy_routing_engine(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Destroying plugin routing engine\n");
 }
 
 /** =========================================================================

--- a/osmeventplugin/src/osmeventplugin.c
+++ b/osmeventplugin/src/osmeventplugin.c
@@ -52,136 +52,49 @@
 #include <opensm/osm_log.h>
 
 /** =========================================================================
- * This is a simple example plugin which:
- *  1) Implement the routing engine API
- *  2) logs some of the events the OSM generates to this interface.
+ * This is a simple example plugin which logs some of the events the OSM
+ * generates to this interface.
  */
-
 #define SAMPLE_PLUGIN_OUTPUT_FILE "/tmp/osm_sample_event_plugin_output"
-
-struct  plugin_t {
-	osm_opensm_t *osm;
+typedef struct _log_events {
 	FILE *log_file;
-};
+	osm_log_t *osmlog;
+} _log_events_t;
 
 /** =========================================================================
- * Forward declarations
- */
-static void *construct(osm_opensm_t *osm);
-
-static void destroy(void *context);
-
-static void report(
-	void *context,
-	osm_epi_event_id_t event_id,
-	void *event_data);
-
-static int plugin_build_lid_matrices(
-	IN void *context);
-
-static int plugin_ucast_build_fwd_tables(
-	IN void *context);
-
-static void plugin_ucast_dump_tables(
-	IN void *context);
-
-static void plugin_update_sl2vl(
-	void *context,
-	IN osm_physp_t *port,
-	IN uint8_t in_port_num,
-	IN uint8_t out_port_num,
-	IN OUT ib_slvl_table_t *t);
-
-static void plugin_update_vlarb(
-	void *context,
-	IN osm_physp_t *port,
-	IN uint8_t port_num,
-	IN OUT ib_vl_arb_table_t *block,
-	unsigned int block_length,
-	unsigned int block_num);
-
-static uint8_t plugin_path_sl(
-	IN void *context,
-	IN uint8_t path_sl_hint,
-	IN const ib_net16_t slid,
-	IN const ib_net16_t dlid);
-
-static ib_api_status_t plugin_mcast_build_stree(
-	IN void *context,
-	IN OUT osm_mgrp_box_t *mgb);
-
-static void plugin_destroy_routing_engine(
-	IN void *context);
-
-static int routing_engine_setup(
-	osm_routing_engine_t *engine,
-	osm_opensm_t *osm);
-
-/** =========================================================================
- * Implement plugin functions
  */
 static void *construct(osm_opensm_t *osm)
 {
-	struct plugin_t *plugin;
-	cl_status_t status;
+	_log_events_t *log = malloc(sizeof(*log));
+	if (!log)
+		return (NULL);
 
-	plugin = (struct plugin_t *) calloc(1, sizeof(struct plugin_t));
-	if (!plugin)
-		return NULL;
+	log->log_file = fopen(SAMPLE_PLUGIN_OUTPUT_FILE, "a+");
 
-	plugin->osm = osm;
-	routing_engine_module_t plugin_routing_engine_module = {
-		 "routing_engine_plugin",
-		  OSM_ROUTING_ENGINE_TYPE_UNKNOWN, /* Generate a new type */
-		  routing_engine_setup,
-		  plugin,
-	};
-
-	status = osm_opensm_register_routing_engine(
-		osm, &plugin_routing_engine_module, plugin);
-	if (status != CL_SUCCESS) {
-		destroy(plugin);
-		return NULL;
-	}
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"External routing engine '%s' has been registered with type '%d'\n",
-		plugin_routing_engine_module.name,
-		plugin_routing_engine_module.type);
-
-	plugin->log_file = fopen(SAMPLE_PLUGIN_OUTPUT_FILE, "a+");
-	if (!(plugin->log_file)) {
+	if (!(log->log_file)) {
 		osm_log(&osm->log, OSM_LOG_ERROR,
 			"Sample Event Plugin: Failed to open output file \"%s\"\n",
 			SAMPLE_PLUGIN_OUTPUT_FILE);
-		destroy(plugin);
-		return NULL;
+		free(log);
+		return (NULL);
 	}
 
-	return ((void *)plugin);
+	log->osmlog = &osm->log;
+	return ((void *)log);
 }
 
 /** =========================================================================
  */
-static void destroy(void *context)
+static void destroy(void *_log)
 {
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	if (plugin) {
-		OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-			"Destroying plugin...\n");
-
-		if (plugin->log_file)
-			fclose(plugin->log_file);
-
-		free(plugin);
-	}
+	_log_events_t *log = (_log_events_t *) _log;
+	fclose(log->log_file);
+	free(log);
 }
 
 /** =========================================================================
  */
-static void handle_port_counter(
-	struct plugin_t *plugin, osm_epi_pe_event_t *pc)
+static void handle_port_counter(_log_events_t * log, osm_epi_pe_event_t * pc)
 {
 	if (pc->symbol_err_cnt > 0
 	    || pc->link_err_recover > 0
@@ -196,7 +109,7 @@ static void handle_port_counter(
 	    || pc->buffer_overrun > 0
 	    || pc->vl15_dropped > 0
 	    || pc->xmit_wait > 0) {
-		fprintf(plugin->log_file,
+		fprintf(log->log_file,
 			"Port counter errors for node 0x%" PRIx64
 			" (%s) port %d\n", pc->port_id.node_guid,
 			pc->port_id.node_name, pc->port_id.port_num);
@@ -206,22 +119,20 @@ static void handle_port_counter(
 /** =========================================================================
  */
 static void
-handle_port_counter_ext(
-	struct plugin_t *plugin, osm_epi_dc_event_t *epc)
+handle_port_counter_ext(_log_events_t * log, osm_epi_dc_event_t * epc)
 {
-	fprintf(plugin->log_file,
-		"Received Data counters for node 0x%" PRIx64 " (%s) port %d\n",
+	fprintf(log->log_file,
+		"Recieved Data counters for node 0x%" PRIx64 " (%s) port %d\n",
 		epc->port_id.node_guid,
 		epc->port_id.node_name, epc->port_id.port_num);
 }
 
 /** =========================================================================
  */
-static void handle_port_select(
-	struct plugin_t *plugin, osm_epi_ps_event_t *ps)
+static void handle_port_select(_log_events_t * log, osm_epi_ps_event_t * ps)
 {
 	if (ps->xmit_wait > 0) {
-		fprintf(plugin->log_file,
+		fprintf(log->log_file,
 			"Port select Xmit Wait counts for node 0x%" PRIx64
 			" (%s) port %d\n", ps->port_id.node_guid,
 			ps->port_id.node_name, ps->port_id.port_num);
@@ -230,17 +141,16 @@ static void handle_port_select(
 
 /** =========================================================================
  */
-static void handle_trap_event(
-	struct plugin_t *plugin, ib_mad_notice_attr_t *p_ntc)
+static void handle_trap_event(_log_events_t *log, ib_mad_notice_attr_t *p_ntc)
 {
 	if (ib_notice_is_generic(p_ntc)) {
-		fprintf(plugin->log_file,
+		fprintf(log->log_file,
 			"Generic trap type %d; event %d; from LID %u\n",
 			ib_notice_get_type(p_ntc),
 			cl_ntoh16(p_ntc->g_or_v.generic.trap_num),
 			cl_ntoh16(p_ntc->issuer_lid));
 	} else {
-		fprintf(plugin->log_file,
+		fprintf(log->log_file,
 			"Vendor trap type %d; from LID %u\n",
 			ib_notice_get_type(p_ntc),
 			cl_ntoh16(p_ntc->issuer_lid));
@@ -250,11 +160,10 @@ static void handle_trap_event(
 
 /** =========================================================================
  */
-static void handle_lft_change_event(
-	struct plugin_t *plugin,
-	osm_epi_lft_change_event_t *lft_change)
+static void handle_lft_change_event(_log_events_t *log,
+				    osm_epi_lft_change_event_t *lft_change)
 {
-	fprintf(plugin->log_file,
+	fprintf(log->log_file,
 		"LFT changed for switch 0x%" PRIx64 " flags 0x%x LFTTop %u block %d\n",
 		cl_ntoh64(osm_node_get_node_guid(lft_change->p_sw->p_node)),
 		lft_change->flags, lft_change->lft_top, lft_change->block_num);
@@ -262,174 +171,51 @@ static void handle_lft_change_event(
 
 /** =========================================================================
  */
-static void report(
-	void *context,
-	osm_epi_event_id_t event_id,
-	void *event_data)
+static void report(void *_log, osm_epi_event_id_t event_id, void *event_data)
 {
-	struct plugin_t *plugin = (struct plugin_t *) context;
+	_log_events_t *log = (_log_events_t *) _log;
 
 	switch (event_id) {
 	case OSM_EVENT_ID_PORT_ERRORS:
-		handle_port_counter(
-			plugin, (osm_epi_pe_event_t *) event_data);
+		handle_port_counter(log, (osm_epi_pe_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_PORT_DATA_COUNTERS:
-		handle_port_counter_ext(
-			plugin, (osm_epi_dc_event_t *) event_data);
+		handle_port_counter_ext(log, (osm_epi_dc_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_PORT_SELECT:
-		handle_port_select(
-			plugin, (osm_epi_ps_event_t *) event_data);
+		handle_port_select(log, (osm_epi_ps_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_TRAP:
-		handle_trap_event(
-			plugin, (ib_mad_notice_attr_t *) event_data);
+		handle_trap_event(log, (ib_mad_notice_attr_t *) event_data);
 		break;
 	case OSM_EVENT_ID_SUBNET_UP:
-		fprintf(plugin->log_file, "Subnet up reported\n");
+		fprintf(log->log_file, "Subnet up reported\n");
 		break;
 	case OSM_EVENT_ID_HEAVY_SWEEP_START:
-		fprintf(plugin->log_file, "Heavy sweep started\n");
+		fprintf(log->log_file, "Heavy sweep started\n");
 		break;
 	case OSM_EVENT_ID_HEAVY_SWEEP_DONE:
-		fprintf(plugin->log_file, "Heavy sweep completed\n");
+		fprintf(log->log_file, "Heavy sweep completed\n");
 		break;
 	case OSM_EVENT_ID_UCAST_ROUTING_DONE:
-		fprintf(plugin->log_file, "Unicast routing completed %d\n",
+		fprintf(log->log_file, "Unicast routing completed %d\n",
 			(osm_epi_ucast_routing_flags_t) event_data);
 		break;
 	case OSM_EVENT_ID_STATE_CHANGE:
-		fprintf(plugin->log_file, "SM state changed\n");
+		fprintf(log->log_file, "SM state changed\n");
 		break;
 	case OSM_EVENT_ID_SA_DB_DUMPED:
-		fprintf(plugin->log_file, "SA DB dump file updated\n");
+		fprintf(log->log_file, "SA DB dump file updated\n");
 		break;
 	case OSM_EVENT_ID_LFT_CHANGE:
-		handle_lft_change_event(
-			plugin, (osm_epi_lft_change_event_t *) event_data);
+		handle_lft_change_event(log, (osm_epi_lft_change_event_t *) event_data);
 		break;
 	case OSM_EVENT_ID_MAX:
 	default:
-		osm_log(&plugin->osm->log, OSM_LOG_ERROR,
+		osm_log(log->osmlog, OSM_LOG_ERROR,
 			"Unknown event (%d) reported to plugin\n", event_id);
 	}
-	fflush(plugin->log_file);
-}
-
-/** =========================================================================
- * Implement routing engine functions
- */
-int routing_engine_setup(
-	osm_routing_engine_t *engine,
-	osm_opensm_t *osm)
-{
-	struct plugin_t *plugin = (struct plugin_t *) engine->context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Setting up the plugin as a new routing engine...\n");
-
-	engine->build_lid_matrices = plugin_build_lid_matrices;
-	engine->ucast_build_fwd_tables = plugin_ucast_build_fwd_tables;
-	engine->ucast_dump_tables = plugin_ucast_dump_tables;
-	engine->update_sl2vl = plugin_update_sl2vl;
-	engine->update_vlarb = plugin_update_vlarb;
-	engine->path_sl = plugin_path_sl;
-	engine->mcast_build_stree = plugin_mcast_build_stree;
-	engine->destroy = plugin_destroy_routing_engine;
-
-	return 0;
-}
-
-static int plugin_build_lid_matrices(
-	IN void *context)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_ERROR,
-		"Building LID matrices...\n");
-
-	return 0;
-}
-
-static int plugin_ucast_build_fwd_tables(
-	IN void *context)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Building Forwarding tables...\n");
-	return 0;
-}
-
-static void plugin_ucast_dump_tables(
-	IN void *context)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Dumping Unicast forwarding tables...\n");
-}
-
-static void plugin_update_sl2vl(
-	void *context,
-	IN osm_physp_t *port,
-	IN uint8_t in_port_num, IN uint8_t out_port_num,
-	IN OUT ib_slvl_table_t *t)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Update Service Layer to Virtual Lanes mapping...\n");
-}
-
-static void plugin_update_vlarb(
-	void *context,
-	IN osm_physp_t *port,
-	IN uint8_t port_num,
-	IN OUT ib_vl_arb_table_t *block,
-	unsigned int block_length,
-	unsigned int block_num)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Update Virtual Lane arbritration...\n");
-}
-
-static uint8_t plugin_path_sl(
-	IN void *context,
-	IN uint8_t path_sl_hint,
-	IN const ib_net16_t slid,
-	IN const ib_net16_t dlid)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Computing Service Layer for the path LID %d -> LID %d with hint: %d...\n",
-		slid, dlid, path_sl_hint);
-	return 0;
-}
-
-static ib_api_status_t plugin_mcast_build_stree(
-	IN void *context,
-	IN OUT osm_mgrp_box_t *mgb)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Building spanning tree for MLID: %d\n",
-		mgb->mlid);
-	return IB_SUCCESS;
-}
-
-static void plugin_destroy_routing_engine(
-	IN void *context)
-{
-	struct plugin_t *plugin = (struct plugin_t *) context;
-
-	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
-		"Destroying plugin routing engine\n");
+	fflush(log->log_file);
 }
 
 /** =========================================================================

--- a/osmroutingplugin/Makefile.am
+++ b/osmroutingplugin/Makefile.am
@@ -1,0 +1,34 @@
+
+AM_CPPFLAGS = -I$(srcdir)/../include \
+	      -I$(includedir)/infiniband
+
+lib_LTLIBRARIES = libosmroutingplugin.la
+
+if DEBUG
+DBGFLAGS = -ggdb -D_DEBUG_
+else
+DBGFLAGS = -g
+endif
+
+libosmroutingplugin_la_CFLAGS = -Wall -Wwrite-strings $(DBGFLAGS) -D_XOPEN_SOURCE=600 -D_GNU_SOURCE=1
+
+if HAVE_LD_VERSION_SCRIPT
+    libosmroutingplugin_version_script = -Wl,--version-script=$(srcdir)/libosmroutingplugin.map
+else
+    libosmroutingplugin_version_script =
+endif
+
+osmroutingplugin_api_version=$(shell grep LIBVERSION= $(srcdir)/libosmroutingplugin.ver | sed 's/LIBVERSION=//')
+
+libosmroutingplugin_la_SOURCES = src/osmroutingplugin.c
+libosmroutingplugin_la_LDFLAGS = -version-info $(osmroutingplugin_api_version) \
+	 -export-dynamic $(libosmroutingplugin_version_script)
+libosmroutingplugin_la_LIBADD = -L../complib -losmcomp -L../libopensm -lopensm $(OSMV_LDADD)
+libosmroutingplugin_la_DEPENDENCIES = $(srcdir)/libosmroutingplugin.map
+
+libosmroutingpluginincludedir = $(includedir)/infiniband/complib
+
+libosmroutingplugininclude_HEADERS =
+
+# headers are distributed as part of the include dir
+EXTRA_DIST = $(srcdir)/libosmroutingplugin.map $(srcdir)/libosmroutingplugin.ver

--- a/osmroutingplugin/libosmroutingplugin.map
+++ b/osmroutingplugin/libosmroutingplugin.map
@@ -1,0 +1,5 @@
+OSMPMDB_1.0 {
+	global:
+	osm_event_plugin;
+	local: *;
+};

--- a/osmroutingplugin/libosmroutingplugin.ver
+++ b/osmroutingplugin/libosmroutingplugin.ver
@@ -1,0 +1,9 @@
+# In this file we track the current API version
+# of the vendor interface (and libraries)
+# The version is built of the following
+# tree numbers:
+# API_REV:RUNNING_REV:AGE
+# API_REV - advance on any added API
+# RUNNING_REV - advance any change to the vendor files
+# AGE - number of backward versions the API still supports
+LIBVERSION=1:2:0

--- a/osmroutingplugin/libosmroutingplugin.ver
+++ b/osmroutingplugin/libosmroutingplugin.ver
@@ -6,4 +6,4 @@
 # API_REV - advance on any added API
 # RUNNING_REV - advance any change to the vendor files
 # AGE - number of backward versions the API still supports
-LIBVERSION=1:2:0
+LIBVERSION=1:0:0

--- a/osmroutingplugin/src/osmroutingplugin.c
+++ b/osmroutingplugin/src/osmroutingplugin.c
@@ -1,7 +1,5 @@
 /*
- * Copyright (c) 2013 Mellanox Technologies LTD. All rights reserved.
- * Copyright (c) 2008 Voltaire, Inc. All rights reserved.
- * Copyright (c) 2007 The Regents of the University of California.
+ * Copyright (C) 2019      Fabriscale Technologies AS. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/osmroutingplugin/src/osmroutingplugin.c
+++ b/osmroutingplugin/src/osmroutingplugin.c
@@ -51,7 +51,7 @@
 #include <opensm/osm_opensm.h>
 #include <opensm/osm_log.h>
 
-/** =========================================================================
+/*
  * This is a simple routing engine plugin
  * which implements the routing engine API
  */
@@ -60,7 +60,7 @@ struct  plugin_t {
 	osm_opensm_t *osm;
 };
 
-/** =========================================================================
+/*
  * Forward declarations
  */
 static void *construct(osm_opensm_t *osm);
@@ -108,7 +108,7 @@ static int routing_engine_setup(
 	osm_routing_engine_t *engine,
 	osm_opensm_t *osm);
 
-/** =========================================================================
+/*
  * Implement plugin functions
  */
 static void *construct(osm_opensm_t *osm)
@@ -142,8 +142,6 @@ static void *construct(osm_opensm_t *osm)
 	return ((void *)plugin);
 }
 
-/** =========================================================================
- */
 static void destroy(void *context)
 {
 	struct plugin_t *plugin = (struct plugin_t *) context;
@@ -156,7 +154,7 @@ static void destroy(void *context)
 	}
 }
 
-/** =========================================================================
+/*
  * Implement routing engine functions
  */
 int routing_engine_setup(
@@ -271,7 +269,7 @@ static void plugin_destroy_routing_engine(
 		"Destroying plugin routing engine\n");
 }
 
-/** =========================================================================
+/*
  * Define the object symbol for loading
  */
 

--- a/osmroutingplugin/src/osmroutingplugin.c
+++ b/osmroutingplugin/src/osmroutingplugin.c
@@ -52,7 +52,8 @@
 #include <opensm/osm_log.h>
 
 /** =========================================================================
- * This is a simple routing engine plugin which implements the routing engine API
+ * This is a simple routing engine plugin
+ * which implements the routing engine API
  */
 
 struct  plugin_t {
@@ -275,11 +276,11 @@ static void plugin_destroy_routing_engine(
  */
 
 #if OSM_EVENT_PLUGIN_INTERFACE_VER != 2
-#error OpenSM plugin interface version missmatch
+#error OpenSM plugin interface version mismatch
 #endif
 
 osm_event_plugin_t osm_event_plugin = {
-      OSM_VERSION,
-      construct,
-      destroy
+	OSM_VERSION,
+	construct,
+	destroy
 };

--- a/osmroutingplugin/src/osmroutingplugin.c
+++ b/osmroutingplugin/src/osmroutingplugin.c
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2013 Mellanox Technologies LTD. All rights reserved.
+ * Copyright (c) 2008 Voltaire, Inc. All rights reserved.
+ * Copyright (c) 2007 The Regents of the University of California.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif				/* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <opensm/osm_config.h>
+#include <complib/cl_qmap.h>
+#include <complib/cl_passivelock.h>
+#include <opensm/osm_version.h>
+#include <opensm/osm_opensm.h>
+#include <opensm/osm_log.h>
+
+/** =========================================================================
+ * This is a simple routing engine plugin which implements the routing engine API
+ */
+
+struct  plugin_t {
+	osm_opensm_t *osm;
+};
+
+/** =========================================================================
+ * Forward declarations
+ */
+static void *construct(osm_opensm_t *osm);
+
+static void destroy(void *context);
+
+static int plugin_build_lid_matrices(
+	IN void *context);
+
+static int plugin_ucast_build_fwd_tables(
+	IN void *context);
+
+static void plugin_ucast_dump_tables(
+	IN void *context);
+
+static void plugin_update_sl2vl(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t in_port_num,
+	IN uint8_t out_port_num,
+	IN OUT ib_slvl_table_t *t);
+
+static void plugin_update_vlarb(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t port_num,
+	IN OUT ib_vl_arb_table_t *block,
+	unsigned int block_length,
+	unsigned int block_num);
+
+static uint8_t plugin_path_sl(
+	IN void *context,
+	IN uint8_t path_sl_hint,
+	IN const ib_net16_t slid,
+	IN const ib_net16_t dlid);
+
+static ib_api_status_t plugin_mcast_build_stree(
+	IN void *context,
+	IN OUT osm_mgrp_box_t *mgb);
+
+static void plugin_destroy_routing_engine(
+	IN void *context);
+
+static int routing_engine_setup(
+	osm_routing_engine_t *engine,
+	osm_opensm_t *osm);
+
+/** =========================================================================
+ * Implement plugin functions
+ */
+static void *construct(osm_opensm_t *osm)
+{
+	struct plugin_t *plugin;
+	cl_status_t status;
+
+	plugin = (struct plugin_t *) calloc(1, sizeof(struct plugin_t));
+	if (!plugin)
+		return NULL;
+
+	plugin->osm = osm;
+	external_routing_engine_module_t plugin_routing_engine_module = {
+		 "routing_engine_plugin",
+		  routing_engine_setup,
+		  plugin,
+	};
+
+	status = osm_register_external_routing_engine(
+		osm, &plugin_routing_engine_module, plugin);
+	if (status != CL_SUCCESS) {
+		destroy(plugin);
+		return NULL;
+	}
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"External routing engine '%s' has been registered with type '%d'\n",
+		plugin_routing_engine_module.name,
+		osm_routing_engine_type(plugin_routing_engine_module.name));
+
+	return ((void *)plugin);
+}
+
+/** =========================================================================
+ */
+static void destroy(void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	if (plugin) {
+		OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+			"Destroying plugin...\n");
+
+		free(plugin);
+	}
+}
+
+/** =========================================================================
+ * Implement routing engine functions
+ */
+int routing_engine_setup(
+	osm_routing_engine_t *engine,
+	osm_opensm_t *osm)
+{
+	struct plugin_t *plugin = (struct plugin_t *) engine->context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Setting up the plugin as a new routing engine...\n");
+
+	engine->build_lid_matrices = plugin_build_lid_matrices;
+	engine->ucast_build_fwd_tables = plugin_ucast_build_fwd_tables;
+	engine->ucast_dump_tables = plugin_ucast_dump_tables;
+	engine->update_sl2vl = plugin_update_sl2vl;
+	engine->update_vlarb = plugin_update_vlarb;
+	engine->path_sl = plugin_path_sl;
+	engine->mcast_build_stree = plugin_mcast_build_stree;
+	engine->destroy = plugin_destroy_routing_engine;
+
+	return 0;
+}
+
+static int plugin_build_lid_matrices(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_ERROR,
+		"Building LID matrices...\n");
+
+	return 0;
+}
+
+static int plugin_ucast_build_fwd_tables(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Building Forwarding tables...\n");
+	return 0;
+}
+
+static void plugin_ucast_dump_tables(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Dumping Unicast forwarding tables...\n");
+}
+
+static void plugin_update_sl2vl(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t in_port_num, IN uint8_t out_port_num,
+	IN OUT ib_slvl_table_t *t)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Update Service Layer to Virtual Lanes mapping...\n");
+}
+
+static void plugin_update_vlarb(
+	void *context,
+	IN osm_physp_t *port,
+	IN uint8_t port_num,
+	IN OUT ib_vl_arb_table_t *block,
+	unsigned int block_length,
+	unsigned int block_num)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Update Virtual Lane arbritration...\n");
+}
+
+static uint8_t plugin_path_sl(
+	IN void *context,
+	IN uint8_t path_sl_hint,
+	IN const ib_net16_t slid,
+	IN const ib_net16_t dlid)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Computing Service Layer for the path LID %d -> LID %d with hint: %d...\n",
+		slid, dlid, path_sl_hint);
+	return 0;
+}
+
+static ib_api_status_t plugin_mcast_build_stree(
+	IN void *context,
+	IN OUT osm_mgrp_box_t *mgb)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Building spanning tree for MLID: %d\n",
+		mgb->mlid);
+	return IB_SUCCESS;
+}
+
+static void plugin_destroy_routing_engine(
+	IN void *context)
+{
+	struct plugin_t *plugin = (struct plugin_t *) context;
+
+	OSM_LOG(&plugin->osm->log, OSM_LOG_INFO,
+		"Destroying plugin routing engine\n");
+}
+
+/** =========================================================================
+ * Define the object symbol for loading
+ */
+
+#if OSM_EVENT_PLUGIN_INTERFACE_VER != 2
+#error OpenSM plugin interface version missmatch
+#endif
+
+osm_event_plugin_t osm_event_plugin = {
+      OSM_VERSION,
+      construct,
+      destroy
+};


### PR DESCRIPTION
- Add new function: osm_opensm_register_routing_engine
- Predefined routing engines (minhop, updn, ...) are registered on startup
- When registering a new plugin, the provided type is used.
  If type is OSM_ROUTING_ENGINE_TYPE_UNKNOWN, a new one is generated.
- osmeventplugin.c: example of event + routing engine plugin
- fix typos: routine engine -> routing engine

Tested with ibsim and the following modifications in opensm.conf:
 - event_plugin_name  osmeventplugin
 - routing_engine     routing_engine_plugin

Linux Kernel Coding style tested with:
  `./checkpatch.pl --terse --file --no-tree opensm/osm_opensm.c osmeventplugin/src/osmeventplugin.c`

`checkpatch.pl` script file downloaded at https://github.com/torvalds/linux/blob/master/scripts/checkpatch.pl

Signed-off-by: Cyrille Verrier <cyrille.verrier@fabriscale.com>