### PR TITLE
sizeof('c')=4, not 1: fix overly-pessimistic IB_INSUFFICIENT_MEMORY return

### DIFF
--- a/libopensm/osm_helper.c
+++ b/libopensm/osm_helper.c
@@ -584,7 +584,7 @@ static ib_api_status_t dbg_do_line(IN char **pp_local, IN uint32_t buf_size,
 	sprintf(line, "%s%s", p_prefix_str, p_new_str);
 	len = (uint32_t) strlen(line);
 	*p_total_len += len;
-	if (*p_total_len + sizeof('\0') > buf_size)
+	if (*p_total_len + 1 /* NUL */ > buf_size)
 		return IB_INSUFFICIENT_MEMORY;
 
 	strcpy(*pp_local, line);


### PR DESCRIPTION
As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793