### PR TITLE
Select the InfiniBand interface first

### DIFF
--- a/include/iba/ib_types.h
+++ b/include/iba/ib_types.h
@@ -9636,6 +9636,24 @@ typedef struct _ib_port_attr_mod {
 *	ib_port_cap_t
 *****/
 
+/****d* Access Layer/ib_link_layer_t
+* NAME
+*	ib_link_layer_t
+*
+* DESCRIPTION
+*	Link layer reported by the transport for a local port.  Used to
+*	prefer InfiniBand ports over RoCE/iWARP when auto-selecting a
+*	default port to bind to.
+*
+* SYNOPSIS
+*/
+typedef enum _ib_link_layer {
+	IB_LINK_LAYER_UNKNOWN = 0,
+	IB_LINK_LAYER_INFINIBAND,
+	IB_LINK_LAYER_ETHERNET
+} ib_link_layer_t;
+/*****/
+
 /****s* Access Layer/ib_port_attr_t
 * NAME
 *	ib_port_attr_t
@@ -9676,6 +9694,7 @@ typedef struct _ib_port_attr {
 	uint16_t qkey_ctr;
 	uint16_t num_gids;
 	uint16_t num_pkeys;
+	ib_link_layer_t link_layer;
 	/*
 	 * Pointers at the end of the structure to allow doing a simple
 	 * memory comparison of contents up to the first pointer.

--- a/libvendor/osm_vendor_ibumad.c
+++ b/libvendor/osm_vendor_ibumad.c
@@ -54,6 +54,7 @@
 
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <linux/types.h>	/* for __be64 with older libibumad */
@@ -687,6 +688,13 @@ osm_vendor_get_all_port_attr(IN osm_vendor_t * const p_vend,
 				attr->sm_lid = ca.ports[j]->sm_lid;
 				attr->sm_sl = ca.ports[j]->sm_sl;
 				attr->link_state = ca.ports[j]->state;
+				if (!strcmp(ca.ports[j]->link_layer, "InfiniBand") ||
+				    !strcmp(ca.ports[j]->link_layer, "IB"))
+					attr->link_layer = IB_LINK_LAYER_INFINIBAND;
+				else if (!strcmp(ca.ports[j]->link_layer, "Ethernet"))
+					attr->link_layer = IB_LINK_LAYER_ETHERNET;
+				else
+					attr->link_layer = IB_LINK_LAYER_UNKNOWN;
 				if (attr->num_pkeys && attr->p_pkey_table) {
 					if (attr->num_pkeys > ca.ports[j]->pkeys_size)
 						attr->num_pkeys = ca.ports[j]->pkeys_size;

--- a/opensm/main.c
+++ b/opensm/main.c
@@ -473,13 +473,28 @@ static ib_net64_t get_port_guid(IN osm_opensm_t * p_osm, uint64_t port_guid)
 		       cl_hton64(attr_array[0].port_guid));
 		return attr_array[0].port_guid;
 	}
-	/* If port_guid is 0 - use the first connected port */
+	/* If port_guid is 0 - use the first connected port.
+	 * Prefer InfiniBand-link-layer ports so that hosts with mixed
+	 * IB + RoCE/iWARP CAs (e.g. mlx5_0 alongside irdma0) do not pick
+	 * an Ethernet port which cannot run a subnet manager. Fall back to
+	 * any up port if no InfiniBand port is available, preserving the
+	 * legacy behavior for vendor backends that do not report a
+	 * link layer (link_layer == IB_LINK_LAYER_UNKNOWN). */
 	if (port_guid == 0) {
-		for (i = 0; i < num_ports; i++)
-			if (attr_array[i].link_state > IB_LINK_DOWN)
+		uint32_t fallback = num_ports;
+		for (i = 0; i < num_ports; i++) {
+			if (attr_array[i].link_state <= IB_LINK_DOWN)
+				continue;
+			if (attr_array[i].link_layer ==
+			    IB_LINK_LAYER_INFINIBAND)
 				break;
+			if (fallback == num_ports &&
+			    attr_array[i].link_layer !=
+			    IB_LINK_LAYER_ETHERNET)
+				fallback = i;
+		}
 		if (i == num_ports)
-			i = 0;
+			i = (fallback < num_ports) ? fallback : 0;
 		printf("Using default GUID 0x%" PRIx64 "\n",
 		       cl_hton64(attr_array[i].port_guid));
 		return attr_array[i].port_guid;


### PR DESCRIPTION
OpenSM currently picks the default interface in alphabetical order and then fails, because the chosen GUID belongs to an Ethernet device.

We should improve the interface selection logic so that OpenSM prefers devices with the "Link layer: InfiniBand" property.